### PR TITLE
Fixes PATH to play nice with other buildpacks

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -83,7 +83,7 @@ configure_app_env_vars() {
   # These exports must point to /app, because the profile is
   # executed in a running dyno, not the buildpack environment
   cat <<EOF > "${BUILD_DIR}/.profile.d/freetds.sh"
-  export PATH="${APP_TARGET_DIR}/bin:$PATH"
+  export PATH="${APP_TARGET_DIR}/bin:\$PATH"
   # tiny_tds extconf.rb uses FREETDS_DIR
   # https://github.com/rails-sqlserver/tiny_tds/blob/5046755ca91594003f8b3ca541d136f3ed859973/ext/tiny_tds/extconf.rb#L36-L38
   export FREETDS_DIR="${APP_TARGET_DIR}"


### PR DESCRIPTION
This fixes the profile so it uses the PATH at time of load instead of the PATH when the profile is compiled. Since $PATH wasn't escaped it was being expanded when the buildpack was installed and would clobber the PATH set by other buildpacks that were loaded before it. I'm guessing profiles are loaded in alphabetical order (ours is dms.sh) which is why we ran into this.