### PR TITLE
upgrade freetds to 1.2.18

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ the [FreeTDS](http://www.freetds.org/) binaries into your project.
 Optionally, set the FreeTDS version in a Heroku config like this:
 
 ```bash
-heroku config:set FREETDS_VERSION=1.00.109
+heroku config:set FREETDS_VERSION=1.2.18
 ```
 
 Make sure the version you're referencing exists on as a `.tar.gz` file on the [FreeTDS releases](ftp://ftp.freetds.org/pub/freetds/stable/).

--- a/bin/compile
+++ b/bin/compile
@@ -58,9 +58,9 @@ load_env_vars() {
 }
 load_env_vars "FREETDS_VERSION" "FREETDS_ARCHIVE_NAME" "TDS_VERSION" "FREETDS_REBUILD"
 
-FREETDS_VERSION="${FREETDS_VERSION:-1.00.109}"
+FREETDS_VERSION="${FREETDS_VERSION:-1.2.18}"
 FREETDS_ARCHIVE_NAME="${FREETDS_ARCHIVE_NAME:-freetds-${FREETDS_VERSION}}"
-TDS_VERSION="${TDS_VERSION:-7.3}" # or TDSVER
+TDS_VERSION="${TDS_VERSION:-7.4}" # or TDSVER
 
 CACHED_TAR="${CACHE_DIR}/freetds-${FREETDS_VERSION}-heroku.tar.bz2"
 # Default rebuild to true since I'm having issues linking the library to tiny_tds gem with a cached build.
@@ -125,7 +125,7 @@ download_and_extract_freetds_archive() {
 }
 
 build_and_install_freetds() {
-  topic "Building FreeTDS against OpenSSL $(openssl version)"
+  topic "Building FreeTDS against GnuTLS"
   ( # directory changes in subshells have no effect
     cd "${BUILD_DIR}/${FREETDS_ARCHIVE_NAME}"
 
@@ -142,7 +142,8 @@ build_and_install_freetds() {
       "--prefix=${APP_TARGET_DIR}" \
       --disable-odbc \
       --disable-debug \
-      "--with-tdsver=${TDS_VERSION}"
+      "--with-tdsver=${TDS_VERSION}" \
+      "--with-gnutls"
 EOF
     # TODO(BF): Print log when HEROKUR_FREETDS_BUILDPACK_DEBUG is set
     /bin/bash .build_options > build_log-configure.stdout.log 2> build_log-configure.stderr.log


### PR DESCRIPTION
on heroku-20 there are some issues with current version of freetds
because of it I couldn't connect to DB

I fix them by upgrading freetds version
tds version
and changing to GnuTLS instead of OpenSSL

as I could find there were a lot problems with tds_version 7.3 over TLS 1.2
and the OpenSSL version on heroku-20 isn't really fresh, that's why better to use gnutls