### PR TITLE
Escape $PATH to ensure dynamic evaluation

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -102,7 +102,7 @@ EOF
 configure_buildpack_env_vars() {
   # These exports point to the build directory, not to /app, so that
   # they work for later buildpacks.
-  export PATH="${BUILD_TARGET_DIR}/bin:$PATH"
+  export PATH="${BUILD_TARGET_DIR}/bin:\$PATH"
   export FREETDS_DIR="${BUILD_TARGET_DIR}"
   export LD_LIBRARY_PATH="${BUILD_TARGET_DIR}/lib:${LD_LIBRARY_PATH:-/usr/local/lib}"
   export LD_RUN_PATH="${BUILD_TARGET_DIR}/lib:${LD_RUN_PATH:-/usr/local/lib}"


### PR DESCRIPTION
What?
=====

This updates the compile script to escape '$' when generating the shell
file, ensuring that $PATH is determined dynamically by
`.profile.d/freetds.sh` rather than writing a snapshot of the value to
disk by evaluating immediately.

Closes #17