### PR TITLE
use gnutls

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Or at least, that's the hope!
 
 ## Stack compatibility
 
-This buildpack is tested primarily against the `cedar-18` stack.
+This buildpack is tested primarily against the `heroku-22` stack.
 
 Allows for usage of [TinyTDS](https://github.com/rails-sqlserver/tiny_tds) on Heroku.
 
@@ -93,6 +93,9 @@ Print TinyTDS build logs to the screen:
 "cat   /app/vendor/bundle/ruby/${RUBY_PATH_VERSION}/extensions/x86_64-linux/${RUBY_PATH_VERSION}-static/tiny_tds-${TINY_TDS_VERSION}/mkmf.log" ; do
 echo -e "\n\n----------------------- $cmd------------------\n\n"; eval "$cmd"; done ; )
 ```
+
+### Connection Timeout
+If you receive connection timeout errors (e.g. "Adaptive Server connection failed"), consider whether TLS/gnutls is interacting poorly with heroku or the server where your mssql server lives.  You can set the environment variable `heroku config:set USE_GNUTLS=" "` and temporarily set `heroku config:set FREETDS_REBUILD=true` to rebuild the code using TLS.  See https://github.com/FreeTDS/freetds/issues/336 for more information.
 
 License
 -------

--- a/bin/compile
+++ b/bin/compile
@@ -140,6 +140,7 @@ build_and_install_freetds() {
     cat <<EOF > ".build_options"
     ./configure \
       "--prefix=${APP_TARGET_DIR}" \
+      --with-gnutls \
       --disable-odbc \
       --disable-debug \
       "--with-tdsver=${TDS_VERSION}"

--- a/bin/compile
+++ b/bin/compile
@@ -141,7 +141,7 @@ build_and_install_freetds() {
 
     # As of Oct. 2022, heroku-22 stack currently only works with gnutls.
     # Allow this to be toggled off in the future with `export USE_GNUTLS=" "`
-    # See https://github.com/FreeTDS/freetds/issues/336 for some mor information.
+    # See https://github.com/FreeTDS/freetds/issues/336 for some more information.
     cat <<EOF > ".build_options"
     ./configure \
       "--prefix=${APP_TARGET_DIR}" \

--- a/bin/compile
+++ b/bin/compile
@@ -141,7 +141,9 @@ build_and_install_freetds() {
 
     # As of Oct. 2022, heroku-22 stack currently only works with gnutls.
     # Allow this to be toggled off in the future with `export USE_GNUTLS=" "`
-    # See https://github.com/FreeTDS/freetds/issues/336 for some more information.
+    # See https://github.com/FreeTDS/freetds/issues/336
+    # and https://www.freetds.org/userguide/config.html
+    # for more information.
     cat <<EOF > ".build_options"
     ./configure \
       "--prefix=${APP_TARGET_DIR}" \

--- a/bin/compile
+++ b/bin/compile
@@ -56,11 +56,12 @@ load_env_vars() {
   local env_var; env_var="${1:-}"
   until [ -z "$env_var" ]; do [ -f "$ENV_DIR/$env_var" ] && export "$env_var=$(cat "$ENV_DIR/$env_var")"; shift ; env_var="${1:-}" ; done
 }
-load_env_vars "FREETDS_VERSION" "FREETDS_ARCHIVE_NAME" "TDS_VERSION" "FREETDS_REBUILD"
+load_env_vars "FREETDS_VERSION" "FREETDS_ARCHIVE_NAME" "TDS_VERSION" "FREETDS_REBUILD" "USE_GNUTLS"
 
 FREETDS_VERSION="${FREETDS_VERSION:-1.00.109}"
 FREETDS_ARCHIVE_NAME="${FREETDS_ARCHIVE_NAME:-freetds-${FREETDS_VERSION}}"
 TDS_VERSION="${TDS_VERSION:-7.3}" # or TDSVER
+USE_GNUTLS="${USE_GNUTLS:---with-gnutls}"
 
 CACHED_TAR="${CACHE_DIR}/freetds-${FREETDS_VERSION}-heroku.tar.bz2"
 # Default rebuild to true since I'm having issues linking the library to tiny_tds gem with a cached build.
@@ -137,10 +138,14 @@ build_and_install_freetds() {
     # FreeTDS advises caching the build options as below
     # adding --disable-odbc making linking easier and we don't need it
     # adding --disable-debug to speed up compile
+
+    # As of Oct. 2022, heroku-22 stack currently only works with gnutls.
+    # Allow this to be toggled off in the future with `export USE_GNUTLS=" "`
+    # See https://github.com/FreeTDS/freetds/issues/336 for some mor information.
     cat <<EOF > ".build_options"
     ./configure \
       "--prefix=${APP_TARGET_DIR}" \
-      --with-gnutls \
+      "${USE_GNUTLS}" \
       --disable-odbc \
       --disable-debug \
       "--with-tdsver=${TDS_VERSION}"


### PR DESCRIPTION
The latest version of TLS/openssl is not working properly with freetds.  See https://github.com/FreeTDS/freetds/issues/336 and https://github.com/FreeTDS/freetds/issues/299

This fix solves https://github.com/rails-sqlserver/heroku-buildpack-freetds/issues/19.  I can now run freetds and tinytds on heroku-22!

FYI @bf4 