### PR TITLE
Escape env vars as expected

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -103,11 +103,11 @@ EOF
 configure_buildpack_env_vars() {
   # These exports point to the build directory, not to /app, so that
   # they work for later buildpacks.
-  export PATH="${BUILD_TARGET_DIR}/bin:$PATH"
+  export PATH="${BUILD_TARGET_DIR}/bin:\$PATH"
   export FREETDS_DIR="${BUILD_TARGET_DIR}"
-  export LD_LIBRARY_PATH="${BUILD_TARGET_DIR}/lib:${LD_LIBRARY_PATH:-/usr/local/lib}"
-  export LD_RUN_PATH="${BUILD_TARGET_DIR}/lib:${LD_RUN_PATH:-/usr/local/lib}"
-  export LIBRARY_PATH="${BUILD_TARGET_DIR}/lib:${LIBRARY_PATH:-/usr/local/lib}"
+  export LD_LIBRARY_PATH="${BUILD_TARGET_DIR}/lib:\${LD_LIBRARY_PATH:-/usr/local/lib}"
+  export LD_RUN_PATH="${BUILD_TARGET_DIR}/lib:\${LD_RUN_PATH:-/usr/local/lib}"
+  export LIBRARY_PATH="${BUILD_TARGET_DIR}/lib:\${LIBRARY_PATH:-/usr/local/lib}"
   export SYBASE="${APP_TARGET_DIR}"
   # give environment to later buildpacks
   export | grep -E -e ' (PATH|LD_LIBRARY_PATH|LIBRARY_PATH|FREETDS_DIR|SYBASE)=' > "${LP_DIR}/export"


### PR DESCRIPTION
Escape when writing to profile.d/freetds.sh

Two commits by Josh Clayton

https://github.com/thoughtbot/heroku-buildpack-freetds/commit/9de3231b68115d44795479a20ffd822ba8ed227c

What?
=====

This updates the compile script to ensure environment variables exported within profile.d/freetds.sh are escaped properly in the script rather than evaluated when the script is run.

The previous behavior evaluated certain environment variables that were intended to be prepended to, resulting in incorrect values in e.g. `LIBRARY_PATH`.

https://github.com/thoughtbot/heroku-buildpack-freetds/commit/6dc7f5887c1e399ce83043065cc51d2f7758ea78

Escape $PATH to ensure dynamic evaluation

What?
=====

This updates the compile script to escape '$' when generating the shell file, ensuring that $PATH is determined dynamically by `.profile.d/freetds.sh` rather than writing a snapshot of the value to disk by evaluating immediately.

Compare to https://github.com/heroku/heroku-buildpack-activestorage-preview/blob/9056773b88c77ff33ff4900f9bb116c41553d5ed/bin/compile

Closes rails-sqlserver#17