### PR TITLE
Revert "Escape env vars as expected"

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -103,11 +103,11 @@ EOF
 configure_buildpack_env_vars() {
   # These exports point to the build directory, not to /app, so that
   # they work for later buildpacks.
-  export PATH="${BUILD_TARGET_DIR}/bin:\$PATH"
+  export PATH="${BUILD_TARGET_DIR}/bin:$PATH"
   export FREETDS_DIR="${BUILD_TARGET_DIR}"
-  export LD_LIBRARY_PATH="${BUILD_TARGET_DIR}/lib:\${LD_LIBRARY_PATH:-/usr/local/lib}"
-  export LD_RUN_PATH="${BUILD_TARGET_DIR}/lib:\${LD_RUN_PATH:-/usr/local/lib}"
-  export LIBRARY_PATH="${BUILD_TARGET_DIR}/lib:\${LIBRARY_PATH:-/usr/local/lib}"
+  export LD_LIBRARY_PATH="${BUILD_TARGET_DIR}/lib:${LD_LIBRARY_PATH:-/usr/local/lib}"
+  export LD_RUN_PATH="${BUILD_TARGET_DIR}/lib:${LD_RUN_PATH:-/usr/local/lib}"
+  export LIBRARY_PATH="${BUILD_TARGET_DIR}/lib:${LIBRARY_PATH:-/usr/local/lib}"
   export SYBASE="${APP_TARGET_DIR}"
   # give environment to later buildpacks
   export | grep -E -e ' (PATH|LD_LIBRARY_PATH|LIBRARY_PATH|FREETDS_DIR|SYBASE)=' > "${LP_DIR}/export"


### PR DESCRIPTION
Reverts rails-sqlserver/heroku-buildpack-freetds#21

Seems this broke the buildpack https://github.com/rails-sqlserver/heroku-buildpack-freetds/issues/23